### PR TITLE
Set X-Forwarded-Email and X-Forwarded-User header in auth-check response

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,6 +37,7 @@
 
 [[constraint]]
   name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify.git"
   version = "~1.2.0"
 
 [[constraint]]

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -585,6 +585,8 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 func (p *OAuthProxy) AuthenticateOnly(rw http.ResponseWriter, req *http.Request) {
 	status := p.Authenticate(rw, req)
 	if status == http.StatusAccepted {
+		rw.Header().Set("X-Forwarded-Email", req.Header.Get("X-Forwarded-Email"))
+		rw.Header().Set("X-Forwarded-User", req.Header.Get("X-Forwarded-User"))
 		rw.WriteHeader(http.StatusAccepted)
 	} else {
 		http.Error(rw, "unauthorized request", http.StatusUnauthorized)


### PR DESCRIPTION
`-set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)`

https://github.com/bitly/oauth2_proxy/blob/master/oauthproxy.go#L692